### PR TITLE
fix: corregida ruta del ícono en el formulario de registro

### DIFF
--- a/formulario-gasto.html
+++ b/formulario-gasto.html
@@ -58,7 +58,7 @@
 
       <!-- Imagen -->
       <aside class="imagen-gasto d-flex align-items-center justify-content-center">
-        <img src="/assets/icons/formulario-gastos.png" class="img-gasto" alt="Icono gasto" />
+        <img src="assets/icons/formulario-gastos.png" class="img-gasto" alt="Icono gasto" />
         <button class="btn-close-custom" id="cerrarFormulario" aria-label="Cerrar formulario">&times;</button>
       </aside>
     </div>


### PR DESCRIPTION
Se corrigió la ruta del ícono en el formulario de registro (formulario-gasto.html) para que se muestre correctamente al eliminar el  '/' inicial.

- Antes: /assets/icons/formulario-gastos.png  
- Ahora: assets/icons/formulario-gastos.png
