### PR TITLE
feat: añadido script para eliminar ingresos con confirmación y opción de deshacer (eliminar-ingreso.js)

### DIFF
--- a/ingresos.html
+++ b/ingresos.html
@@ -44,8 +44,8 @@
             <div class="collapse show" id="submenuRegistros">
               <ul class="nav flex-column ms-4 mt-2 submenu-registros">
                 <li><a href="#" class="nav-link nav-gastos"><i class="bi bi-plus-lg me-2"></i>Ingresos</a></li>
-                <li><a href="#" class="nav-link text-white"><i class="bi bi-dash-lg me-2"></i>Gastos</a></li>
-                <li><a href="#" class="nav-link text-white"><i class="bi bi-bar-chart me-2"></i>Balance</a></li>
+                <li><a href="gastos.html" class="nav-link text-white"><i class="bi bi-dash-lg me-2"></i>Gastos</a></li>
+                <li><a href="balance.html" class="nav-link text-white"><i class="bi bi-bar-chart me-2"></i>Balance</a></li>
               </ul>
             </div>
           </li>
@@ -166,9 +166,41 @@
       </footer>
     </div>
   </div>
+  
+  <!-- Confirmación -->
+<template id="confirmacion-template">
+  <tr class="fila-confirmacion">
+    <td colspan="5">
+      <div class="d-flex justify-content-between align-items-center p-3 area-confirmacion">
+        <span class="fw-bold">¿Desea eliminar este ingreso?</span>
+        <div>
+          <button class="btn btn-outline-secondary me-2 cancelar-eliminacion">Cancelar</button>
+          <button class="btn btn-warning confirmar-eliminacion">Eliminar</button>
+        </div>
+      </div>
+    </td>
+  </tr>
+</template>
+
+<!-- Toast de éxito -->
+<template id="toast-template">
+  <div class="toast-exito shadow rounded d-flex align-items-center justify-content-between p-3 notificacion-toast">
+    <div class="d-flex align-items-center justify-content-between w-100">
+      <div class="d-flex align-items-center">
+        <div class="check-circle rounded-circle me-3 d-flex justify-content-center align-items-center">
+          <i class="bi bi-check-lg"></i>
+        </div>
+        <span class="text-white fw-bold">Ingreso eliminado con éxito</span>
+      </div>
+      <button class="btn btn-warning btn-sm fw-bold btn-deshacer ms-3">Deshacer</button>
+    </div>
+  </div>
+ </template>
 
   <!-- Bootstrap JS -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <!-- Custom JS -->
+  <script src="scripts/eliminar-ingreso.js"></script>
 
 </body>
 </html>

--- a/scripts/eliminar-ingreso.js
+++ b/scripts/eliminar-ingreso.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const tabla = document.getElementById('tablaIngresos');
+  const templateConfirmacion = document.getElementById('confirmacion-template');
+  const templateToast = document.getElementById('toast-template');
+  let filaEliminada = null;
+  let datosFila = null;
+
+  tabla.addEventListener('click', function (e) {
+    if (e.target.classList.contains('eliminar-fila')) {
+      const fila = e.target.closest('tr');
+      mostrarConfirmacion(fila);
+    }
+  });
+
+  function mostrarConfirmacion(fila) {
+    eliminarConfirmacionExistente();
+
+    fila.classList.add('table-active');
+    const nuevaFila = templateConfirmacion.content.cloneNode(true);
+    const filaConfirmacion = nuevaFila.querySelector('tr');
+    fila.parentNode.insertBefore(filaConfirmacion, fila.nextSibling);
+
+    filaConfirmacion.querySelector('.cancelar-eliminacion').addEventListener('click', () => {
+      fila.classList.remove('table-active');
+      filaConfirmacion.remove();
+    });
+
+    filaConfirmacion.querySelector('.confirmar-eliminacion').addEventListener('click', () => {
+      datosFila = [...fila.children].map(td => td.innerHTML);
+      filaEliminada = fila;
+      fila.remove();
+      filaConfirmacion.remove();
+      mostrarToastExito();
+    });
+  }
+
+  function eliminarConfirmacionExistente() {
+    const confirmacion = document.querySelector('.fila-confirmacion');
+    if (confirmacion) {
+      const anterior = confirmacion.previousElementSibling;
+      if (anterior) anterior.classList.remove('table-active');
+      confirmacion.remove();
+    }
+  }
+
+  function mostrarToastExito() {
+    eliminarToastExistente();
+    const toast = templateToast.content.cloneNode(true).children[0];
+    document.body.appendChild(toast);
+
+    toast.querySelector('.btn-deshacer').addEventListener('click', function () {
+      if (filaEliminada && datosFila) {
+        const nuevaFila = document.createElement('tr');
+        nuevaFila.innerHTML = datosFila.map(cell => `<td>${cell}</td>`).join('');
+        tabla.querySelector('tbody').prepend(nuevaFila);
+        filaEliminada = null;
+        datosFila = null;
+        toast.remove();
+      }
+    });
+
+    setTimeout(() => toast.remove(), 5000);
+  }
+
+  function eliminarToastExistente() {
+    const prev = document.querySelector('.toast-exito');
+    if (prev) prev.remove();
+  }
+});


### PR DESCRIPTION
Se realizaron las siguientes modificaciones en la vista de ingresos:
- Se añadieron los hipervínculos a los botones de navegación hacia ingresos.html y balance.html dentro del menú lateral.
- Se incluyeron los templates necesarios (<template>) para la confirmación de eliminación y el toast de éxito con opción de deshacer.
- Se creó el archivo scripts/eliminar-ingreso.js, el cual contiene la lógica que permite eliminar un ingreso con confirmación previa y deshacer la acción si se desea.