### PR TITLE
fix: se uniformizó el estilo del toast de eliminación para ingresos y gastos

### DIFF
--- a/gastos.html
+++ b/gastos.html
@@ -18,8 +18,8 @@
 
   <!-- Custom CSS -->
   <link rel="stylesheet" href="styles/styles.css">
-  <link rel="stylesheet" href="styles/gastos.css" />
-  <link rel="stylesheet" href="styles/filtrar-calendario.css" />
+  <link rel="stylesheet" href="styles/gastos.css">
+  <link rel="stylesheet" href="styles/filtrar-calendario.css">
 
 </head>
 <body class="layout-wrapper">

--- a/ingresos.html
+++ b/ingresos.html
@@ -18,9 +18,8 @@
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="styles/styles.css">
-    <link rel="stylesheet" href="styles/ingresos.css" />
-    <link rel="stylesheet" href="styles/formulario-ingresos.css" />
-    <link rel="stylesheet" href="styles/filtrar-calendario.css" />
+    <link rel="stylesheet" href="styles/ingresos.css">
+    <link rel="stylesheet" href="styles/filtrar-calendario.css">
 </head>
 <body class="layout-wrapper">
 

--- a/styles/gastos.css
+++ b/styles/gastos.css
@@ -21,7 +21,7 @@
 .toast-exito {
   position: fixed;
   bottom: 20px;
-  left: 50%;
+  left: 55%;
   transform: translateX(-50%);
   z-index: 9999;
   background-color: var(--color-primario);
@@ -52,7 +52,7 @@
 .toast-registro {
   position: fixed;
   bottom: 2rem;
-  left: 45%;
+  left: 55%;
   z-index: 9999;
   background-color: var(--color-primario);
   color: white;

--- a/styles/ingresos.css
+++ b/styles/ingresos.css
@@ -21,7 +21,7 @@
 .toast-exito {
   position: fixed;
   bottom: 20px;
-  left: 50%;
+  left: 55%;
   transform: translateX(-50%);
   z-index: 9999;
   background-color: var(--color-primario);


### PR DESCRIPTION
Se corrigió el estilo del toast de eliminación para que tenga una apariencia uniforme en las vistas de ingresos y gastos.

- Antes, el toast de ingresos se mostraba como un cuadro grande y centrado, mientras que el de gastos tenía un diseño más compacto y ubicado en la parte inferior.
- Ahora ambos comparten el mismo diseño compacto, con posición fija y estilos consistentes para el ícono, el mensaje y el botón "Deshacer".

