### PR TITLE
fix(responsive): se ocultó correctamente la imagen de perfil en pantallas ≤768px

### DIFF
--- a/styles/home.css
+++ b/styles/home.css
@@ -635,7 +635,7 @@ body.bienvenido-wrapper {
   }
 }
 
-@media screen and (max-height: 600px) {
+@media screen and (max-width: 768px) {
   .foto-perfil-container {
     display: none !important;
   }


### PR DESCRIPTION
Se realizaron ajustes en el diseño responsive para mejorar la visualización en dispositivos móviles:
- En la vista de home.html se ocultó correctamente la imagen de perfil (.foto-perfil-container y .avatar-header) en pantallas con ancho menor o igual a 768px.